### PR TITLE
Status page fixes

### DIFF
--- a/f1-total_genomes/fig1.R
+++ b/f1-total_genomes/fig1.R
@@ -14,10 +14,10 @@ p <- ggplot(dfc, aes(x=published_date, y=cumsum(pag_count))) +
     geom_area(
         fill="#002366"
     ) +
-    scale_x_date(expand=c(0,0), date_labels = "%b\n%Y", date_breaks = "1 month", limit=c(as.Date("2020-03-01"),max(df$published_date))) +
+    scale_x_date(expand=c(0,0), date_labels = "%b\n%Y", date_breaks = "6 months", limit=c(as.Date("2020-03-01"),max(df$published_date))) +
     scale_y_continuous(
         expand=c(0.0,0),
-        breaks=seq(0,sum(dfc$pag_count),100000),
+        breaks=seq(0,sum(dfc$pag_count),200000),
         minor_breaks=c(),
         labels=scales::comma,
         limits=c(0,sum(dfc$pag_count)+10000)

--- a/f2-lamps/fig2.R
+++ b/f2-lamps/fig2.R
@@ -11,7 +11,7 @@ df <- df %>%
     complete(service, date = seq.Date(min(df$date), as.Date(args[2]), by="days"))
 df[is.na(df$go),]$go <- FALSE
 
-CUTOFF_DAYS <- 90
+CUTOFF_DAYS <- 30
 start_cutoff <- as.Date(args[2]) - CUTOFF_DAYS # N days ago
 df <- df[df$date >= start_cutoff,]
 df <- df[df$date <= as.Date(args[2]),]


### PR DESCRIPTION
- Changed date cutoff for service status graph to be 30 days rather than 90 (in line with other graphs).
- Changed x axis breaks on cumulative graph from 1 to 6 months.
- Changed y axis breaks on cumulative graph from 100k to 200k.